### PR TITLE
fix: APICacheTimeout for API cache TTL; honor AllowStale on fallback

### DIFF
--- a/mirror.go
+++ b/mirror.go
@@ -62,7 +62,9 @@ type Mirror interface {
 
 // MirrorConfig is the configuration structure for the caching downloader.
 type MirrorConfig struct {
-	// AllowStale enables using stale cached resources if the download fails.
+	// AllowStale enables returning stale cached API responses or artifacts when the pull-through download or
+	// ListVersions request fails (offline / error path). When false, those failures propagate instead of serving
+	// expired cache entries.
 	AllowStale bool `json:"allow_stale"`
 	// APICacheTimeout is the time the cached API JSON should be considered valid. A duration of 0 means the API
 	// responses should not be cached. A duration of -1 means the API responses should be cached indefinitely.

--- a/mirror_download_artifact.go
+++ b/mirror_download_artifact.go
@@ -29,9 +29,11 @@ func (m *mirror) DownloadArtifact(ctx context.Context, version VersionWithArtifa
 		return artifact, nil
 	}
 
-	cachedArtifact, err = m.tryReadArtifactCache(m.storage, version.ID, artifactName, true)
-	if err == nil {
-		return cachedArtifact, nil
+	if m.config.AllowStale {
+		cachedArtifact, err = m.tryReadArtifactCache(m.storage, version.ID, artifactName, true)
+		if err == nil {
+			return cachedArtifact, nil
+		}
 	}
 	return nil, onlineErr
 }

--- a/mirror_list_versions.go
+++ b/mirror_list_versions.go
@@ -34,10 +34,12 @@ func (m *mirror) ListVersions(ctx context.Context, opts ...ListVersionOpt) ([]Ve
 		return versions, nil
 	}
 
-	// Fetch stale cached version:
-	cachedVersions, err = m.tryReadVersionCache(m.storage, opts, true)
-	if err == nil {
-		return cachedVersions, nil
+	// Optionally return stale cached version after online failure (see MirrorConfig.AllowStale).
+	if m.config.AllowStale {
+		cachedVersions, err = m.tryReadVersionCache(m.storage, opts, true)
+		if err == nil {
+			return cachedVersions, nil
+		}
 	}
 	return nil, onlineErr
 }
@@ -50,7 +52,7 @@ func (m *mirror) tryReadVersionCache(storage MirrorStorage, opts []ListVersionOp
 	defer func() {
 		_ = cacheReader.Close()
 	}()
-	if !allowStale && m.config.ArtifactCacheTimeout > 0 && storeTime.Add(m.config.ArtifactCacheTimeout).Before(time.Now()) {
+	if !allowStale && m.config.APICacheTimeout > 0 && storeTime.Add(m.config.APICacheTimeout).Before(time.Now()) {
 		return nil, &CachedAPIResponseStaleError{}
 	}
 	return fetchVersions(opts, func() (io.ReadCloser, error) {

--- a/mirror_list_versions_test.go
+++ b/mirror_list_versions_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package tofudl
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testMirrorStorageStub implements MirrorStorage for API cache tests only.
+type testMirrorStorageStub struct {
+	apiJSON string
+	apiTime time.Time
+}
+
+func (s *testMirrorStorageStub) ReadAPIFile() (io.ReadCloser, time.Time, error) {
+	return io.NopCloser(strings.NewReader(s.apiJSON)), s.apiTime, nil
+}
+
+func (s *testMirrorStorageStub) StoreAPIFile([]byte) error { return nil }
+
+func (s *testMirrorStorageStub) ReadArtifact(Version, string) (io.ReadCloser, time.Time, error) {
+	return nil, time.Time{}, &CacheMissError{"", nil}
+}
+
+func (s *testMirrorStorageStub) StoreArtifact(Version, string, []byte) error { return nil }
+
+func TestTryReadVersionCacheUsesAPICacheTimeout(t *testing.T) {
+	t.Parallel()
+
+	const minimalAPI = `{"versions":[]}`
+
+	t.Run("fresh_by_api_timeout", func(t *testing.T) {
+		t.Parallel()
+		m := &mirror{
+			config: MirrorConfig{
+				APICacheTimeout:      time.Hour,
+				ArtifactCacheTimeout:   time.Nanosecond, // must not affect API staleness
+			},
+			storage: &testMirrorStorageStub{
+				apiJSON: minimalAPI,
+				apiTime: time.Now().Add(-30 * time.Minute),
+			},
+		}
+		_, err := m.tryReadVersionCache(m.storage, nil, false)
+		if err != nil {
+			t.Fatalf("tryReadVersionCache: %v", err)
+		}
+	})
+
+	t.Run("stale_by_api_timeout", func(t *testing.T) {
+		t.Parallel()
+		m := &mirror{
+			config: MirrorConfig{
+				APICacheTimeout:      time.Hour,
+				ArtifactCacheTimeout: -1,
+			},
+			storage: &testMirrorStorageStub{
+				apiJSON: minimalAPI,
+				apiTime: time.Now().Add(-2 * time.Hour),
+			},
+		}
+		_, err := m.tryReadVersionCache(m.storage, nil, false)
+		var stale *CachedAPIResponseStaleError
+		if err == nil {
+			t.Fatal("expected CachedAPIResponseStaleError")
+		}
+		if !errors.As(err, &stale) {
+			t.Fatalf("got %T, want *CachedAPIResponseStaleError", err)
+		}
+	})
+
+	t.Run("indefinite_api_cache_negative_timeout", func(t *testing.T) {
+		t.Parallel()
+		m := &mirror{
+			config: MirrorConfig{
+				APICacheTimeout:      -1,
+				ArtifactCacheTimeout: time.Nanosecond,
+			},
+			storage: &testMirrorStorageStub{
+				apiJSON: minimalAPI,
+				apiTime: time.Now().Add(-365 * 24 * time.Hour),
+			},
+		}
+		_, err := m.tryReadVersionCache(m.storage, nil, false)
+		if err != nil {
+			t.Fatalf("with APICacheTimeout -1, old file should not be stale: %v", err)
+		}
+	})
+
+	t.Run("allowStale_skips_api_ttl", func(t *testing.T) {
+		t.Parallel()
+		m := &mirror{
+			config: MirrorConfig{
+				APICacheTimeout: time.Second,
+			},
+			storage: &testMirrorStorageStub{
+				apiJSON: minimalAPI,
+				apiTime: time.Now().Add(-time.Hour),
+			},
+		}
+		_, err := m.tryReadVersionCache(m.storage, nil, true)
+		if err != nil {
+			t.Fatalf("allowStale: %v", err)
+		}
+	})
+}

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -69,7 +69,8 @@ func TestMirroringE2E(t *testing.T) {
 
 	cache2, err := tofudl.NewMirror(
 		tofudl.MirrorConfig{
-			AllowStale:           false,
+			// Offline path must allow stale cache entries when the pull-through URL is unreachable.
+			AllowStale:           true,
 			APICacheTimeout:      -1,
 			ArtifactCacheTimeout: -1,
 		},


### PR DESCRIPTION
## Summary

Fixes incorrect use of `ArtifactCacheTimeout` when deciding whether the cached API JSON (`api.json`) is stale: the mirror now uses **`APICacheTimeout`**, matching `MirrorConfig` documentation.

Also wires **`AllowStale`** so that fallback to expired cache after a failed pull-through `ListVersions` or `DownloadArtifact` only happens when `AllowStale` is `true`. Previously that fallback always ignored the flag.

## Changes

- `tryReadVersionCache`: stale check uses `APICacheTimeout > 0` and `storeTime.Add(APICacheTimeout)`; `APICacheTimeout <= 0` (e.g. `-1` indefinite) does not age out the API file by time.
- `ListVersions` / `DownloadArtifact`: offline/error fallback to stale cache gated on `m.config.AllowStale`.
- `MirrorConfig.AllowStale` comment clarified.
- Unit tests for API cache TTL; `TestMirroringE2E` sets `AllowStale: true` for the offline cache scenario.

Closes #13.

## Testing

`go test . -run 'TestTryReadVersionCache|TestMirroring|TestMirror'`